### PR TITLE
Correct Response Code for a Forbidden Action

### DIFF
--- a/api/policies/ownUser.js
+++ b/api/policies/ownUser.js
@@ -3,7 +3,7 @@ module.exports = function(req, res, next) {
   var currentUserId = req.token.sid;
 
   if (userId != currentUserId) {
-    return res.json(400, {err: 'You are not allowed to do that'}); // Is 400 correct here?
+    return res.json(403, {err: 'You are not allowed to do that'});
   }
 
   next();


### PR DESCRIPTION
Taken from the status codes definition page on [w3.org](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html): 
#403 Forbidden

"The server understood the request, but is refusing to fulfill it. Authorization will not help and the request SHOULD NOT be repeated. If the request method was not HEAD and the server wishes to make public why the request has not been fulfilled, it SHOULD describe the reason for the refusal in the entity. If the server does not wish to make this information available to the client, the status code 404 (Not Found) can be used instead."
