### PR TITLE
Update ownAssociations.js

### DIFF
--- a/api/policies/ownAssociations.js
+++ b/api/policies/ownAssociations.js
@@ -3,7 +3,7 @@ module.exports = function(req, res, next) {
   var currentUserId = req.token.sid;
 
   if (userId != currentUserId) {
-    return res.json(400, {err: 'You are not allowed to do that'}); // Is 400 correct here?
+    return res.json(403, {err: 'You are not allowed to do that'});
   }
 
   next();


### PR DESCRIPTION
I believe that since the criteria for success in this query is based upon the user having permissions to access the resource, I changed the status to a 403 Forbidden. This is because it can't be a 401 - Unauthorized as the req.token.sid assumes they are already logged in and a 400 is more suited to a malformed request. 

An alternative and arguably more "Sails.js" solution making use of the response feature would be: return res.forbidden('You are not allow to do that');

But this is totally fine too. Good work! :)