### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-contrib-less": "~0.10.0",
     "grunt-contrib-coffee": "~0.10.1",
     "jsonwebtoken": "~0.4.0",
-    "bcrypt": "~0.7.8",
+    "bcrypt": "~0.8.3",
     "grunt-html2js": "~0.2.6"
   },
   "scripts": {


### PR DESCRIPTION
bcrypt 0.7 is not compatible with latest 0.12 node version and so npm install was failing.
That should fix the issue.